### PR TITLE
Allow updating the initial country

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -143,8 +143,16 @@ export default class PhoneInput extends Component {
   didRender() {
     this._super(...arguments)
 
-    if (this.number && this._iti) {
+    if (!this._iti) {
+      return
+    }
+
+    if (this.number) {
       this._iti.setNumber(this.number)
+    }
+
+    if (this.initialCountry) {
+      this._iti.setCountry(this.initialCountry)
     }
   }
 

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -38,4 +38,25 @@ module('Integration | Component | phone-input', function(hooks) {
 
     assert.dom('input').hasValue(newValue)
   })
+
+  test('it can update the country', async function(assert) {
+    assert.expect(2)
+
+    await this.owner.lookup('service:phone-input').load()
+
+    const country = 'us'
+    this.set('number', null)
+    this.set('update', () => {})
+    this.set('country', country)
+
+    await render(
+      hbs`{{phone-input initialCountry=country number=number update=(action update)}}`
+    )
+
+    assert.dom('.iti-flag').hasClass('us')
+
+    await this.set('country', 'nz')
+
+    assert.dom('.iti-flag').hasClass('nz')
+  })
 })


### PR DESCRIPTION
The `phone-input` component is apart of a profile form where a user is adding their country and the phone number. Auto updating the `phone-input` country allows for a smoother UI.  

The use case: 
https://cl.ly/ab3127a9c9d3
