### PR TITLE
Switch quote mark

### DIFF
--- a/addon/services/phone-input.js
+++ b/addon/services/phone-input.js
@@ -24,12 +24,12 @@ export default class PhoneInputService extends Service {
     const doLoadScript1 = this.didLoad
       ? Promise.resolve()
       : loadScript(
-          this._loadUrl(`assets/ember-phone-input/scripts/intlTelInput.min.js`)
+          this._loadUrl('assets/ember-phone-input/scripts/intlTelInput.min.js')
         )
 
     const doLoadScript2 = this.didLoad
       ? Promise.resolve()
-      : loadScript(this._loadUrl(`assets/ember-phone-input/scripts/utils.js`))
+      : loadScript(this._loadUrl('assets/ember-phone-input/scripts/utils.js'))
 
     return Promise.all([doLoadScript1, doLoadScript2]).then(() => {
       if (this.isDestroyed) {


### PR DESCRIPTION
The use of \` causes the url to be incorrectly fingerprinted and you end up getting something like ```this._loadUrl(/dashboard/`assets/ember-phone-input/scripts/intlTelInput.min-7731cac69a6973827342840ada953cf3.js\`)```.