### PR TITLE
Remove ember-decorators dependency

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -2,7 +2,6 @@
 
 import Component from '@ember/component'
 import { assert } from '@ember/debug'
-import { attribute, tagName } from '@ember-decorators/component'
 
 const { intlTelInput } = window
 
@@ -23,13 +22,15 @@ const PHONE_NUMBER_FORMAT = 'E164' // https://en.wikipedia.org/wiki/E.164
   @class PhoneInput
   @public
 */
-@tagName('input')
-export default class PhoneInput extends Component {
-  @attribute
-  type = 'tel'
+
+export default Component.extend({
+  tagName: 'input',
+
+  attributeBindings: ['type'],
+  type: 'tel',
 
   init() {
-    super.init(...arguments)
+    this._super(...arguments)
 
     this._iti = this._iti || null
 
@@ -109,7 +110,7 @@ export default class PhoneInput extends Component {
       "`autoPlaceholder` possible values are 'polite', 'aggressive' and 'off'",
       validAutoPlaceholer
     )
-  }
+  },
 
   input() {
     const format = intlTelInputUtils.numberFormat[PHONE_NUMBER_FORMAT]
@@ -119,10 +120,10 @@ export default class PhoneInput extends Component {
     this.update(internationalPhoneNumber, meta)
 
     return true
-  }
+  },
 
   didInsertElement() {
-    super.didInsertElement(...arguments)
+    this._super(...arguments)
 
     const {
       autoPlaceholder,
@@ -152,7 +153,7 @@ export default class PhoneInput extends Component {
     }
 
     this.update(number, this._metaData(_iti))
-  }
+  },
 
   // this is a trick to format the number on user input
   didRender() {
@@ -169,13 +170,13 @@ export default class PhoneInput extends Component {
     if (this.number) {
       this._iti.setNumber(this.number)
     }
-  }
+  },
 
   willDestroyElement() {
     this._iti.destroy()
 
-    super.willDestroyElement(...arguments)
-  }
+    this._super(...arguments)
+  },
 
   _metaData(iti) {
     const extension = iti.getExtension()
@@ -188,4 +189,4 @@ export default class PhoneInput extends Component {
       isValidNumber
     }
   }
-}
+})

--- a/addon/services/phone-input.js
+++ b/addon/services/phone-input.js
@@ -1,12 +1,13 @@
 import Service from '@ember/service'
 import { getOwner } from '@ember/application'
 import loadScript from 'ember-phone-input/utils/load-script'
+import RSVP from 'rsvp'
 
-export default class PhoneInputService extends Service {
-  didLoad = this.didLoad || false
+export default Service.extend({
+  didLoad: false,
 
   init() {
-    super.init(...arguments)
+    this._super(...arguments)
 
     const config = getOwner(this).resolveRegistration('config:environment')
     const { lazyLoad, hasPrepend } = config.phoneInput
@@ -18,27 +19,27 @@ export default class PhoneInputService extends Service {
       // that is to say at the app boot
       this.load()
     }
-  }
+  },
 
   load() {
     const doLoadScript1 = this.didLoad
-      ? Promise.resolve()
+      ? RSVP.resolve()
       : loadScript(
           this._loadUrl('assets/ember-phone-input/scripts/intlTelInput.min.js')
         )
 
     const doLoadScript2 = this.didLoad
-      ? Promise.resolve()
+      ? RSVP.resolve()
       : loadScript(this._loadUrl('assets/ember-phone-input/scripts/utils.js'))
 
-    return Promise.all([doLoadScript1, doLoadScript2]).then(() => {
+    return RSVP.all([doLoadScript1, doLoadScript2]).then(() => {
       if (this.isDestroyed) {
         return
       }
 
       this.set('didLoad', true)
     })
-  }
+  },
 
   _loadUrl(url) {
     const { rootURL } = getOwner(this).resolveRegistration('config:environment')
@@ -46,4 +47,4 @@ export default class PhoneInputService extends Service {
 
     return `${prependUrl}${url}`
   }
-}
+})

--- a/package.json
+++ b/package.json
@@ -34,15 +34,12 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/babel-transforms": "^3.1.0",
     "babel-eslint": "^10.0.1",
     "ember-cli-babel": "^7.1.4",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-decorators": "^3.1.5",
     "intl-tel-input": "^14.0.7"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.0",
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^2.7.0",

--- a/tests/dummy/app/pods/application/route.js
+++ b/tests/dummy/app/pods/application/route.js
@@ -1,11 +1,10 @@
 import Route from '@ember/routing/route'
-import { service } from '@ember-decorators/service'
+import { inject as service } from '@ember/service'
 
-export default class ApplicationRoute extends Route {
-  @service
-  phoneInput
+export default Route.extend({
+  phoneInput: service(),
 
   async beforeModel() {
     await this.get('phoneInput').load()
   }
-}
+})

--- a/tests/dummy/app/pods/docs/components/phone-input/action-handling/component.js
+++ b/tests/dummy/app/pods/docs/components/phone-input/action-handling/component.js
@@ -10,14 +10,3 @@ export default Component.extend({
     // END-SNIPPET
   }
 })
-
-// import Controller from '@ember/controller'
-// import { action } from '@ember-decorators/object'
-
-// export default class DocsUsageController extends Controller {
-//   @action
-//   handleUpdate(number, metaData) {
-//     this.set('number', number)
-//     this.setProperties(metaData)
-//   }
-// }

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile'
 module('Integration | Component | phone-input', function(hooks) {
   setupRenderingTest(hooks)
 
-  test('it renders an input of type tel', async function(assert) {
+  test('renders an input of type tel', async function(assert) {
     assert.expect(1)
 
     await this.owner.lookup('service:phone-input').load()
@@ -16,7 +16,7 @@ module('Integration | Component | phone-input', function(hooks) {
     assert.dom('input').hasAttribute('type', 'tel')
   })
 
-  test('it renders the value', async function(assert) {
+  test('renders the value', async function(assert) {
     assert.expect(3)
 
     await this.owner.lookup('service:phone-input').load()
@@ -39,7 +39,7 @@ module('Integration | Component | phone-input', function(hooks) {
     assert.dom('input').hasValue(newValue)
   })
 
-  test('it can update the country', async function(assert) {
+  test('can update the country', async function(assert) {
     assert.expect(2)
 
     await this.owner.lookup('service:phone-input').load()

--- a/tests/unit/services/phone-input-test.js
+++ b/tests/unit/services/phone-input-test.js
@@ -10,9 +10,9 @@ module('Unit | Service | phone-input', function(hooks) {
 
     const service = this.owner.lookup('service:phone-input')
 
-    const url = `assets/ember-phone-input/scripts/intlTelInput.min.js`
+    const url = 'assets/ember-phone-input/scripts/intlTelInput.min.js'
 
-    const expectedUrl = `assets/ember-phone-input/scripts/intlTelInput.min.js`
+    const expectedUrl = 'assets/ember-phone-input/scripts/intlTelInput.min.js'
     assert.equal(service._loadUrl(url), expectedUrl)
   })
 
@@ -22,9 +22,9 @@ module('Unit | Service | phone-input', function(hooks) {
 
     const service = this.owner.lookup('service:phone-input')
 
-    const url = `assets/ember-phone-input/scripts/intlTelInput.min.js`
+    const url = 'assets/ember-phone-input/scripts/intlTelInput.min.js'
 
-    const expectedUrl = `/assets/ember-phone-input/scripts/intlTelInput.min.js`
+    const expectedUrl = '/assets/ember-phone-input/scripts/intlTelInput.min.js'
     assert.equal(service._loadUrl(url), expectedUrl)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,7 +28,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.6", "@babel/core@^7.2.0":
+"@babel/core@^7.1.6":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687"
   integrity sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==
@@ -79,16 +79,6 @@
     "@babel/helper-hoist-variables" "^7.0.0"
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
-
-"@babel/helper-create-class-features-plugin@^7.2.1":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.2.1.tgz#f6e8027291669ef64433220dc8327531233f1161"
-  dependencies:
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-member-expression-to-functions" "^7.0.0"
-    "@babel/helper-optimise-call-expression" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.1.0"
 
 "@babel/helper-define-map@^7.1.0":
   version "7.1.0"
@@ -231,6 +221,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.2.tgz#37ebdbc88a2e1ebc6c8dd3d35ea9436e3e39e477"
   integrity sha512-UNTmQ5cSLDeBGBl+s7JeowkqIHgmFAGBnLDdIzFmUNSuS5JF0XBcN59jsh/vJO/YjfsBqMxhMjoFGmNExmf0FA==
 
+"@babel/parser@^7.2.3":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.2.tgz#95cdeddfc3992a6ca2a1315191c1679ca32c55cd"
+  integrity sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==
+
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
@@ -238,22 +233,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
-
-"@babel/plugin-proposal-class-properties@^7.1.0":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.2.1.tgz#c734a53e0a1ec40fe5c22ee5069d26da3b187d05"
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.2.1"
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-proposal-decorators@^7.1.2":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.2.0.tgz#6b4278282a6f5dd08b5d89b94f21aa1671fea071"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/plugin-syntax-decorators" "^7.2.0"
 
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
@@ -287,12 +266,6 @@
 "@babel/plugin-syntax-async-generators@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-decorators@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz#c50b1b957dcc69e4b1127b65e1c33eef61570c1b"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -581,7 +554,7 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6", "@babel/traverse@^7.2.2":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.2.tgz#961039de1f9bcb946d807efe2dba9c92e859d188"
   integrity sha512-E5Bn9FSwHpSkUhthw/XEuvFZxIgrqb9M8cX8j5EUQtrUG5DQUy6bFyl7G7iQ1D1Czudor+xkmp81JbLVVM0Sjg==
@@ -610,6 +583,21 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.2.2":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
+  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.2.2"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.2.3"
+    "@babel/types" "^7.2.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.2.tgz#44e10fc24e33af524488b716cdaee5360ea8ed1e"
@@ -618,60 +606,6 @@
     esutils "^2.0.2"
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
-
-"@ember-decorators/babel-transforms@^3.1.0":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/babel-transforms/-/babel-transforms-3.1.5.tgz#6df543f7f1d862ad54d05555d548805e032f6514"
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.1.0"
-    "@babel/plugin-proposal-decorators" "^7.1.2"
-    ember-cli-babel-plugin-helpers "^1.0.0"
-    ember-cli-version-checker "^2.1.0"
-
-"@ember-decorators/component@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-3.1.5.tgz#65c0f62a3dcf3434178d454031aabea33792ccbb"
-  dependencies:
-    "@ember-decorators/utils" "^3.1.5"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/controller@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/controller/-/controller-3.1.5.tgz#300c40b98aae0dfb21b6f9a882278ec47f919e4d"
-  dependencies:
-    "@ember-decorators/utils" "^3.1.5"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/data@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/data/-/data-3.1.5.tgz#84494a8b5d55e9328789f37d84dd52e2f4d51cd3"
-  dependencies:
-    "@ember-decorators/utils" "^3.1.5"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/object@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-3.1.5.tgz#51de623b99edf4ee116b62f775fa57a270af5b52"
-  dependencies:
-    "@ember-decorators/utils" "^3.1.5"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/service@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/service/-/service-3.1.5.tgz#ed5ab1fdb3d59659b3c4911797761f79958550f9"
-  dependencies:
-    "@ember-decorators/utils" "^3.1.5"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/utils@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-3.1.5.tgz#8f692582329a88553192e998012c7ca59e547c37"
-  dependencies:
-    babel-plugin-debug-macros "^0.1.11"
-    ember-cli-babel "^7.1.3"
-    ember-cli-version-checker "^2.1.2"
-    ember-compatibility-helpers "^1.1.2"
-    semver "^5.6.0"
 
 "@ember/jquery@^0.5.2":
   version "0.5.2"
@@ -1610,7 +1544,7 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
+babel-plugin-debug-macros@^0.1.10:
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
   integrity sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==
@@ -4529,10 +4463,6 @@ ember-cli-autoprefixer@^0.8.1:
     broccoli-autoprefixer "^5.0.0"
     lodash "^4.0.0"
 
-ember-cli-babel-plugin-helpers@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.0.2.tgz#d4bec0f32febc530e621ea8d66d3365727cb5e6c"
-
 ember-cli-babel@7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.1.3.tgz#a2a7374adb525369a3a205cedd54d8e0c3de3309"
@@ -4555,7 +4485,7 @@ ember-cli-babel@7.1.3:
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.2, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -4574,7 +4504,25 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4:
+ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.2:
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz#f0d53d2fb95e70c15d8db84760d045f88f458f69"
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.5.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.4.2.tgz#9d7daa165b509e41f6dc3bb443ae32072f766aa2"
   integrity sha512-5PJOkQ3B3Cvef2nQVPuZSPA6ckwiED3qF4cqzu7jcKhZ0Fy2TwPqABVbiPBJ46NujAsMZrjverVRST74Q25GqQ==
@@ -4590,6 +4538,27 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     babel-plugin-ember-modules-api-polyfill "^2.6.0"
     babel-plugin-module-resolver "^3.1.1"
     broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.1.4.tgz#5f2b6ba2156d8dce2681aea92689b57ffbc71ccb"
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.5.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.0"
     broccoli-debug "^0.6.4"
     broccoli-funnel "^2.0.1"
     broccoli-source "^1.1.0"
@@ -5020,7 +4989,7 @@ ember-code-snippet@^2.4.0:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2:
+ember-compatibility-helpers@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
   dependencies:
@@ -5103,18 +5072,6 @@ ember-copy@^1.0.0:
     resolve "^1.8.1"
     semver "^5.5.0"
     silent-error "^1.1.0"
-
-ember-decorators@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-3.1.5.tgz#4920982ac5546d5e72af3d8dcb66dd96e48c01a6"
-  dependencies:
-    "@ember-decorators/component" "^3.1.5"
-    "@ember-decorators/controller" "^3.1.5"
-    "@ember-decorators/data" "^3.1.5"
-    "@ember-decorators/object" "^3.1.5"
-    "@ember-decorators/service" "^3.1.5"
-    ember-cli-babel "^7.1.3"
-    semver "^5.5.0"
 
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
@@ -11745,7 +11702,7 @@ select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
Remove the decorators from the `phone-input` component
updated super
adding input type

http://phone-input.surge.sh -> use this branch
http://phone-input-broken.surge.sh -> uses `2.0.5`

The above app can be found here 
https://github.com/kiwiupover/phone-input
https://github.com/kiwiupover/phone-input/tree/broken 


