### PR TITLE
Make sure correct path is used for intl-tel-input assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const Funnel = require('broccoli-funnel')
 const MergeTrees = require('broccoli-merge-trees')
+const path = require('path')
 
 const scriptsDestDir = 'assets/ember-phone-input/scripts/'
 const intlTelInputScriptName = 'intlTelInput.min.js'
@@ -31,7 +32,8 @@ module.exports = {
   treeForPublic() {
     // copy these files to destDir
     // to be able to lazyLoad them || not to bundle them into vendor.js
-    const intlTelInputFiles = new Funnel('node_modules/intl-tel-input', {
+    const intlTelInputPath = path.resolve(require.resolve('intl-tel-input'), '..');
+    const intlTelInputFiles = new Funnel(intlTelInputPath, {
       srcDir: '/build/js',
       include: [intlTelInputScriptName, utilsScriptName],
       destDir: `/${scriptsDestDir}`

--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ module.exports = {
   treeForPublic() {
     // copy these files to destDir
     // to be able to lazyLoad them || not to bundle them into vendor.js
-    const intlTelInputPath = path.resolve(require.resolve('intl-tel-input'), '..');
+    const intlTelInputPath = path.resolve(
+      require.resolve('intl-tel-input'),
+      '..'
+    );
     const intlTelInputFiles = new Funnel(intlTelInputPath, {
       srcDir: '/build/js',
       include: [intlTelInputScriptName, utilsScriptName],

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     const intlTelInputPath = path.resolve(
       require.resolve('intl-tel-input'),
       '..'
-    );
+    )
     const intlTelInputFiles = new Funnel(intlTelInputPath, {
       srcDir: '/build/js',
       include: [intlTelInputScriptName, utilsScriptName],


### PR DESCRIPTION
Resolve the path of `intl-tel-input`, regardless of which `node_modules` folder it's in.

I was getting an error `Attempting to watch missing directory: node_modules/intl-tel-input`, when using this with Yarn Workspaces, as the package is in the root `node_modules` folder