### PR TITLE
Remove ember-cli-htmlbars-inline-precompile to get rid of the deprecation warning while building

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ember-cli-deploy-git": "^1.3.3",
     "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-favicon": "^2.2.0",
-    "ember-cli-htmlbars": "^4.0.8",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-release": "^1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "ember-cli-babel": "^7.1.4",
-    "ember-cli-htmlbars": "^4.0.2",
+    "ember-cli-htmlbars": "^4.0.8",
     "intl-tel-input": "^15.0.2"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
     "ember-cli-deploy-git": "^1.3.3",
     "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-favicon": "^2.2.0",
-    "ember-cli-htmlbars-inline-precompile": "^3.0.0",
+    "ember-cli-htmlbars": "^4.0.8",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-release": "^1.0.0-beta.2",

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit'
 import { setupRenderingTest } from 'ember-qunit'
 import { fillIn, render } from '@ember/test-helpers'
-import hbs from 'htmlbars-inline-precompile'
+import { hbs } from 'ember-cli-htmlbars'
 
 module('Integration | Component | phone-input', function(hooks) {
   setupRenderingTest(hooks)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2374,11 +2374,6 @@ babel-plugin-htmlbars-inline-precompile@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
   integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
-babel-plugin-htmlbars-inline-precompile@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-2.1.1.tgz#59edd4eab28d27fbafa26d51bc19795278d103a9"
-  integrity sha512-obo5//IFrEZNAQovcXxOXLn5nwkQ0Y+xhR7AMg1sYR6W7KxQLZI9/XzbIytVhjwwY+Bd2e0+qyHEplJbHyZ1Og==
-
 babel-plugin-htmlbars-inline-precompile@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.0.0.tgz#95aa0d2379347cda9a7127c028fe35cb39179fa2"
@@ -5578,18 +5573,6 @@ ember-cli-htmlbars-inline-precompile@^2.1.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars-inline-precompile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-3.0.1.tgz#dc1f6fbc3bb5e51d01ca334e692c7f0b5e298d57"
-  integrity sha512-mLGJjxEPiOFty9HVM7LHg+5cfM1M9lwbEBmlanZMM333cnwvgZulKjTYU0/e0tpWDvNvPdX8rM+/Leh0TIrqqA==
-  dependencies:
-    babel-plugin-htmlbars-inline-precompile "^2.1.0"
-    ember-cli-version-checker "^3.1.3"
-    hash-for-dep "^1.5.1"
-    heimdalljs-logger "^0.1.9"
-    semver "^6.3.0"
-    silent-error "^1.1.0"
-
 ember-cli-htmlbars@^2.0.1, ember-cli-htmlbars@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz#b5a105429a6bce4f7c9c97b667e3b8926e31397f"
@@ -5610,7 +5593,7 @@ ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
     json-stable-stringify "^1.0.1"
     strip-bom "^3.0.0"
 
-ember-cli-htmlbars@^4.0.2:
+ember-cli-htmlbars@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.0.8.tgz#e87b62e7040bd478a2d007053bdb1644dd1685b0"
   integrity sha512-B6fzlqmv2E2dl8P6UIYu3bY8nZU2kKfl1VkEIgxFAINfsu9fP65kX/bKzHqGhHF8nAtWBoXZWw6tomHKfUT/Jg==


### PR DESCRIPTION
It seems that [ember-cli-htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile) is deprecated it is suggested to use [ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars) more details can be found [here](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/298)

You can import `hbs` from **ember-cli-htmlbars** it should look like this:
``` javascript 
import { hbs } from 'ember-cli-htmlbars' 
```