### PR TITLE
Remove obsolete `tough-cookie` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,6 @@
     "prettier": "^1.15.3",
     "qunit-dom": "^0.9.0"
   },
-  "resolutions": {
-    "**/tough-cookie": "~2.4.0"
-  },
   "engines": {
     "node": "8.* || >= 10.*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13872,13 +13872,18 @@ topo@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-tough-cookie@>=0.12.0, tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.4.3, tough-cookie@~2.2.0, tough-cookie@~2.4.0, tough-cookie@~2.4.3:
+tough-cookie@>=0.12.0, tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.4.3, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+tough-cookie@~2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.2.2.tgz#c83a1830f4e5ef0b93ef2a3488e724f8de016ac7"
+  integrity sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=
 
 tr46@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This is no longer needed because we don't support Node 6 anymore

/cc @dcyriller 