### PR TITLE
package.json: Move `babel-eslint` into `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "babel-eslint": "^10.0.1",
     "ember-cli-babel": "^7.1.4",
     "ember-cli-htmlbars": "^4.0.8",
     "intl-tel-input": "^15.0.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
+    "babel-eslint": "^10.0.1",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.1",


### PR DESCRIPTION
I don't see any reason why we would need this as a production dependency 🤔 