### PR TITLE
Move script loading when `lazyLoad:false`

### DIFF
--- a/addon/instance-initializers/phone-input.js
+++ b/addon/instance-initializers/phone-input.js
@@ -1,0 +1,12 @@
+export function initialize(appInstance) {
+  const config = appInstance.resolveRegistration('config:environment');
+  const { lazyLoad } = config.phoneInput;
+
+  if (!lazyLoad) {
+    appInstance.lookup('service:phone-input').load();
+  }
+}
+
+export default {
+  initialize
+};

--- a/addon/services/phone-input.js
+++ b/addon/services/phone-input.js
@@ -1,22 +1,8 @@
 import Service from '@ember/service';
-import { getOwner } from '@ember/application';
 import RSVP from 'rsvp';
 
 export default Service.extend({
   intlTelInput: null,
-
-  init() {
-    this._super(...arguments);
-
-    const config = getOwner(this).resolveRegistration('config:environment');
-    const { lazyLoad } = config.phoneInput;
-
-    if (!lazyLoad) {
-      // if lazyLoad is disabled, load them now
-      // that is to say at the app boot
-      this.load();
-    }
-  },
 
   load() {
     if (this.intlTelInput) return;

--- a/app/instance-initializers/phone-input.js
+++ b/app/instance-initializers/phone-input.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize
+} from 'ember-phone-input/instance-initializers/phone-input';


### PR DESCRIPTION
from `phoneInput` service to an instance-initializer.

#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."
Second iteration for https://github.com/qonto/ember-phone-input/pull/154

I thought the init hook of a service would be run at app boot. It was a
mistake.

Enter an instance-initializer, which does that.

Should close https://github.com/qonto/ember-phone-input/issues/155 and https://github.com/qonto/ember-phone-input/issues/156
