### PR TITLE
Add numberFormat meta if number is valid

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,9 @@ module.exports = {
     browser: true,
     es6: true
   },
+  globals: {
+    intlTelInputUtils: true
+  },
   rules: {
     'prettier/prettier': 2
   },

--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -257,11 +257,24 @@ export default Component.extend({
     const extension = iti.getExtension();
     const selectedCountryData = iti.getSelectedCountryData();
     const isValidNumber = iti.isValidNumber();
+    // From https://github.com/jackocnr/intl-tel-input/blob/master/src/js/utils.js#L102
+    const E164 = iti.getNumber(0);
+    const INTERNATIONAL = iti.getNumber(1);
+    const NATIONAL = iti.getNumber(2);
+    const RFC3966 = iti.getNumber(3);
 
     return {
       extension,
       selectedCountryData,
-      isValidNumber
+      isValidNumber,
+      numberFormat: isValidNumber
+        ? {
+            E164,
+            INTERNATIONAL,
+            NATIONAL,
+            RFC3966
+          }
+        : null
     };
   }
 });

--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -257,11 +257,12 @@ export default Component.extend({
     const extension = iti.getExtension();
     const selectedCountryData = iti.getSelectedCountryData();
     const isValidNumber = iti.isValidNumber();
-    // From https://github.com/jackocnr/intl-tel-input/blob/master/src/js/utils.js#L102
-    const E164 = iti.getNumber(0);
-    const INTERNATIONAL = iti.getNumber(1);
-    const NATIONAL = iti.getNumber(2);
-    const RFC3966 = iti.getNumber(3);
+    const E164 = iti.getNumber(intlTelInputUtils.numberFormat.E164);
+    const INTERNATIONAL = iti.getNumber(
+      intlTelInputUtils.numberFormat.INTERNATIONAL
+    );
+    const NATIONAL = iti.getNumber(intlTelInputUtils.numberFormat.NATIONAL);
+    const RFC3966 = iti.getNumber(intlTelInputUtils.numberFormat.RFC3966);
 
     return {
       extension,

--- a/tests/dummy/app/pods/docs/components/phone-input/all-options/template.hbs
+++ b/tests/dummy/app/pods/docs/components/phone-input/all-options/template.hbs
@@ -14,6 +14,13 @@
       <li>the phone number validity <em>\{{isValidNumber}}: </em><strong>{{isValidNumber}}</strong></li>
       <li>the phone number extension <em>\{{extension}}</em>: <strong>{{extension}}</strong></li>
     </ul>
+    <p><b>If the number is valid</b>, you also get different formats:</p>
+    <ul>
+      <li>E164 format <em>\{{numberFormat.E164}}</em>: <strong>{{numberFormat.E164}}</strong></li>
+      <li>INTERNATIONAL format <em>\{{numberFormat.INTERNATIONAL}}</em>: <strong>{{numberFormat.INTERNATIONAL}}</strong></li>
+      <li>NATIONAL format <em>\{{numberFormat.NATIONAL}}</em>: <strong>{{numberFormat.NATIONAL}}</strong></li>
+      <li>RFC3966 format <em>\{{numberFormat.RFC3966}}</em>: <strong>{{numberFormat.RFC3966}}</strong></li>
+    </ul>
   {{/demo.example}}
 
   {{demo.snippet "phone-input-all-options.hbs"}}
@@ -56,7 +63,7 @@
       <p>The input is required.</p>
 
       <p>The input is required and you will not be able to submit the form when the field is empty as the clients-side HTML5 form validation will prvent it.</p>
-      
+
       <button name="button" type="submit" class="docs-bg-grey-darkest docs-text-white docs-no-underline docs-rounded docs-py-2 docs-px-4">submit</button>
     </form>
   {{/demo.example}}

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -80,7 +80,7 @@ module('Integration | Component | phone-input', function(hooks) {
   });
 
   test('phoneNumber is correctly invalid when country is changed', async function(assert) {
-    assert.expect(2);
+    assert.expect(7);
 
     const country = 'fr';
     const validFrenchNumber = '0622334455';
@@ -92,14 +92,19 @@ module('Integration | Component | phone-input', function(hooks) {
       hbs`{{phone-input country=country number=number update=(action update)}}`
     );
 
-    this.set('update', (number, { isValidNumber }) => {
+    this.set('update', (number, { isValidNumber, numberFormat }) => {
       assert.ok(isValidNumber);
+      assert.equal(numberFormat.E164, '+33622334455');
+      assert.equal(numberFormat.INTERNATIONAL, '+33 6 22 33 44 55');
+      assert.equal(numberFormat.NATIONAL, '06 22 33 44 55');
+      assert.equal(numberFormat.RFC3966, 'tel:+33-6-22-33-44-55');
     });
 
     await fillIn('input', validFrenchNumber);
 
-    this.set('update', (number, { isValidNumber }) => {
+    this.set('update', (number, { isValidNumber, numberFormat }) => {
       assert.notOk(isValidNumber);
+      assert.equal(numberFormat, null);
     });
 
     this.set('country', 'pt');


### PR DESCRIPTION
#### Description
Add `numberFormat` in meta to get all formats available.
As investigated in #241 those formats are only available if phone number is valid.

#### Screenshots

Valid phone number
![2020-07-24-152845_1606x1353_scrot](https://user-images.githubusercontent.com/1716173/88407953-6a5c3a00-cdc2-11ea-801b-40d2f358a995.png)

Invalid phone number
![2020-07-24-152855_1521x1359_scrot](https://user-images.githubusercontent.com/1716173/88407952-692b0d00-cdc2-11ea-96f2-207db3dd1422.png)

