### PR TITLE
add formatOnDisplay option to JS file to have ability to control format with component parameter

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -82,6 +82,16 @@ export default Component.extend({
       : true;
 
     /**
+      add option to control input format
+      @argument formatOnDisplay
+      @type {boolean}
+    */
+
+    this.formatOnDisplay = isPresent(this.formatOnDisplay)
+      ? this.formatOnDisplay
+      : true;
+
+    /**
       Add or remove input placeholder with an example number for the selected
       country. Possible values are 'polite', 'aggressive' and 'off'. Defaults to
       'polite'.
@@ -207,7 +217,8 @@ export default Component.extend({
       initialCountry,
       onlyCountries,
       preferredCountries,
-      separateDialCode
+      separateDialCode,
+      formatOnDisplay
     } = this;
 
     var input = document.getElementById(this.elementId);
@@ -219,7 +230,8 @@ export default Component.extend({
       initialCountry,
       onlyCountries,
       preferredCountries,
-      separateDialCode
+      separateDialCode,
+      formatOnDisplay
     });
 
     if (this.number) {


### PR DESCRIPTION
#### Description
Bug fixed in this PR related to **intl-tel-input** library.
In short - we need option to disable validation, because:
Letters on input transformed to numbers. 
**formatOnDisplay** option helps disable this behaviour. Just declared it in JS file. Feature already have description in docs.

#### Changes
[//]: # "Add if relevant, remove if not"
* formatOnDisplay option declared in JS file

#### Screenshots
**Before:**
(last 3 signs was "7890qwe" - transformed to numbers)
![image](https://user-images.githubusercontent.com/61147655/90498855-8056e380-e151-11ea-9cda-13305f58655c.png)

**After:**
![image](https://user-images.githubusercontent.com/61147655/90486737-15ea7700-e142-11ea-9da8-ad26447b8e8f.png)

#### Reproduction instructions
[//]: # "Please add instructions to reproduce the changes."
→ 

### Checklist 
- [x] Obvisously, add your option

- [x] Do not forget to write inline documentation for your code in addon/components/phone-input

- [x] Add a test, probably in tests/integration/components/phone-input-test.js - **sorry, have no idea how to test this**

- [x] Add a playground example in tests/dummy/app/pods/docs/components/phone-input/all-options/template - **again it's hard, because problem appears only in pair with third-party package**