### PR TITLE
Add conditions to check if code typed in is valid

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -249,7 +249,12 @@ export default Component.extend({
   },
 
   _onCountryChange() {
-    this._iti.setCountry(this._iti.getSelectedCountryData().iso2);
+    const selectedCountry = this._iti.getSelectedCountryData();
+
+    if (selectedCountry.iso2) {
+      this._iti.setCountry(selectedCountry.iso2);
+    }
+
     this.input();
   },
 

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('number', null);
     this.set('update', () => {});
 
-    await render(hbs`{{phone-input number=number update=(action update)}}`);
+    await render(hbs`<PhoneInput @number={{this.number}} @update={{this.update}} />`);
 
     assert.dom('input').hasValue('');
 
@@ -49,7 +49,7 @@ module('Integration | Component | phone-input', function(hooks) {
     });
 
     await render(
-      hbs`{{phone-input separateDialCode=true number=separateDialNumber update=(action update)}}`
+      hbs`<PhoneInput @separateDialCode={{true}} @number={{this.separateDialNumber}} @update={{action this.update}} />`
     );
 
     assert.dom('input').hasValue('');
@@ -69,7 +69,7 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('country', country);
 
     await render(
-      hbs`{{phone-input country=country number=number update=(action update)}}`
+      hbs`<PhoneInput @country={{this.country}} @number={{this.number}} @update={{action this.update}} />`
     );
 
     assert.dom('.iti__flag').hasClass('iti__us');
@@ -89,7 +89,7 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('update', () => {});
 
     await render(
-      hbs`{{phone-input country=country number=number update=(action update)}}`
+      hbs`<PhoneInput @country={{this.country}} @number={{this.number}} @update={{action this.update}} />`
     );
 
     this.set('update', (number, { isValidNumber, numberFormat }) => {
@@ -114,12 +114,12 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('number', null);
     this.set('update', () => {});
 
-    await render(hbs`{{phone-input number=number update=(action update)}}`);
+    await render(hbs`<PhoneInput @number={{this.number}} @update={{action this.update}} />`);
 
     assert.notOk(find('input').disabled);
 
     await render(
-      hbs`{{phone-input disabled=true number=number update=(action update)}}`
+      hbs`<PhoneInput @disabled={{true}} @number={{this.number}} @update={{action this.update}} />`
     );
     assert.ok(find('input').disabled);
   });
@@ -127,11 +127,11 @@ module('Integration | Component | phone-input', function(hooks) {
   test('can be required', async function(assert) {
     this.set('number', null);
 
-    await render(hbs`{{phone-input number=number}}`);
+    await render(hbs`<PhoneInput @number={{this.number}} />`);
 
     assert.notOk(find('input').required);
 
-    await render(hbs`{{phone-input required=true number=number}}`);
+    await render(hbs`<PhoneInput @required={{true}} @number={{this.number}}}}`);
 
     assert.ok(find('input').required);
   });
@@ -142,14 +142,14 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('updateAllowDropdownNumber', () => {});
 
     await render(
-      hbs`{{phone-input allowDropdown=false update=(action updateAllowDropdownNumber)}}`
+      hbs`<PhoneInput @allowDropdown={{false}} @update={{action this.updateAllowDropdownNumber}} />`
     );
 
     assert.dom('ul.country-list').doesNotExist();
   });
 
   test('can set autocomplete', async function(assert) {
-    await render(hbs`{{phone-input autocomplete="tel"}}`);
+    await render(hbs`<PhoneInput @autocomplete={{"tel"}} />`);
 
     assert.equal(find('input').autocomplete, 'tel');
   });

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, render, find } from '@ember/test-helpers';
+import { fillIn, render, find, typeIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | phone-input', function(hooks) {
@@ -152,5 +152,25 @@ module('Integration | Component | phone-input', function(hooks) {
     await render(hbs`<PhoneInput @autocomplete={{"tel"}} />`);
 
     assert.equal(find('input').autocomplete, 'tel');
+  });
+
+  test('can update the country when the user types in the digits from Brazil code', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`<PhoneInput />`);
+
+    await typeIn('input', '+55');
+
+    assert.dom('.iti__flag').hasClass('iti__br');
+  });
+
+  test('can update the country when the user types in the digits from Malaysia code', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`<PhoneInput />`);
+
+    await typeIn('input', '+60');
+
+    assert.dom('.iti__flag').hasClass('iti__my');
   });
 });

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -131,7 +131,7 @@ module('Integration | Component | phone-input', function(hooks) {
 
     assert.notOk(find('input').required);
 
-    await render(hbs`<PhoneInput @required={{true}} @number={{this.number}}}}`);
+    await render(hbs`<PhoneInput @required={{true}} @number={{this.number}} />`);
 
     assert.ok(find('input').required);
   });

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -25,7 +25,9 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('number', null);
     this.set('update', () => {});
 
-    await render(hbs`<PhoneInput @number={{this.number}} @update={{this.update}} />`);
+    await render(
+      hbs`<PhoneInput @number={{this.number}} @update={{this.update}} />`
+    );
 
     assert.dom('input').hasValue('');
 
@@ -114,7 +116,9 @@ module('Integration | Component | phone-input', function(hooks) {
     this.set('number', null);
     this.set('update', () => {});
 
-    await render(hbs`<PhoneInput @number={{this.number}} @update={{action this.update}} />`);
+    await render(
+      hbs`<PhoneInput @number={{this.number}} @update={{action this.update}} />`
+    );
 
     assert.notOk(find('input').disabled);
 
@@ -131,7 +135,9 @@ module('Integration | Component | phone-input', function(hooks) {
 
     assert.notOk(find('input').required);
 
-    await render(hbs`<PhoneInput @required={{true}} @number={{this.number}} />`);
+    await render(
+      hbs`<PhoneInput @required={{true}} @number={{this.number}} />`
+    );
 
     assert.ok(find('input').required);
   });


### PR DESCRIPTION
#### Description
It's happening with Brazil (+55) and Malaysia (+60) code, for example.

intl-tel-input does not provide code 5 or 6 in countryCodes object  
![image](https://user-images.githubusercontent.com/308948/91614492-0811ce80-e958-11ea-8bb1-2e4378ac508c.png)

When the user types in `+55`, the `_onCountryChange` get an error because `this._iti.getSelectedCountryData()` returns empty value and tries to get `this._iti.getSelectedCountryData().iso2` value.

#### Changes
* Change - add condition on `_onCountryChange` to check if `this._iti.getSelectedCountryData()` is valid object
* Change - convert tests to Angle Bracket Syntax

#### Reproduction instructions
[//]: # "Please add instructions to reproduce the changes."
→ Types in (don't copy and paste) the full Brazil phone number, like "+55 62 99503-0404"

