### PR TITLE
Fix conditions to check if code typed in is valid

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -253,9 +253,9 @@ export default Component.extend({
 
     if (selectedCountry.iso2) {
       this._iti.setCountry(selectedCountry.iso2);
-    }
 
-    this.input();
+      this.input();
+    }
   },
 
   _metaData(iti) {

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -161,21 +161,45 @@ module('Integration | Component | phone-input', function(hooks) {
   });
 
   test('can update the country when the user types in the digits from Brazil code', async function(assert) {
-    assert.expect(1);
+    assert.expect(5);
 
-    await render(hbs`<PhoneInput />`);
+    const code = '+55';
 
-    await typeIn('input', '+55');
+    let slicePosition = 1;
+
+    this.set('update', value => {
+      if (value) {
+        assert.equal(code.slice(0, slicePosition), value);
+
+        slicePosition += 1;
+      }
+    });
+
+    await render(hbs`<PhoneInput @update={{action this.update}} />`);
+
+    await typeIn('input', code);
 
     assert.dom('.iti__flag').hasClass('iti__br');
   });
 
   test('can update the country when the user types in the digits from Malaysia code', async function(assert) {
-    assert.expect(1);
+    assert.expect(5);
 
-    await render(hbs`<PhoneInput />`);
+    const code = '+60';
 
-    await typeIn('input', '+60');
+    let slicePosition = 1;
+
+    this.set('update', value => {
+      if (value) {
+        assert.equal(code.slice(0, slicePosition), value);
+
+        slicePosition += 1;
+      }
+    });
+
+    await render(hbs`<PhoneInput @update={{action this.update}} />`);
+
+    await typeIn('input', code);
 
     assert.dom('.iti__flag').hasClass('iti__my');
   });


### PR DESCRIPTION
#### Description
This PR solves the problem causes by https://github.com/qonto/ember-phone-input/pull/255. I've add `this.input()` inside the "if".

![image](https://user-images.githubusercontent.com/308948/94279251-3d431980-ff22-11ea-9756-7506836c453b.png)


Also, I've removed "fillIn"helper in favor "typeIn" as discussed here https://github.com/qonto/ember-phone-input/pull/255#discussion_r484891164

#### Changes
* Added `this.input();` inside `if (selectedCountry.iso2) {`
* removed `fillIn` helper in favor `typeIn`

#### Reproduction instructions
→ call the component defining `@updated` action (<PhoneInput @update={{action this.update}} />)

### Checklist 
- [x] Fix bug when the user uses update action

- [x] Improve the tests to uses `typeIn` helper