### PR TITLE
add 'allowAutoFormat' option to disable automatic transformation letters -> numbers

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -163,7 +163,7 @@ export default Component.extend({
 
   input(event) {
     var meta = this._metaData(this._iti);
-    let internationalPhoneNumber;
+    var internationalPhoneNumber;
     
     if (this.allowAutoFormat) {
       internationalPhoneNumber = this._iti.getNumber();

--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -168,7 +168,7 @@ export default Component.extend({
     if (this.allowAutoFormat) {
       internationalPhoneNumber = this._iti.getNumber();
     } else {
-      const countryCode = meta.selectedCountryData;
+      const countryCode = meta.selectedCountryData.dialCode;
       internationalPhoneNumber = `+${countryCode} ${event.target.value}`;
     }
 

--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -80,9 +80,7 @@ export default Component.extend({
       @type {boolean}
     */
 
-    this.allowAutoFormat = isPresent(this.allowAutoFormat)
-      ? this.allowAutoFormat
-      : true;
+    this.allowAutoFormat = this.allowAutoFormat || true;
 
     /**
       Add or remove input placeholder with an example number for the selected

--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -8,6 +8,7 @@ import { isPresent } from '@ember/utils';
   ```hbs
     {{phone-input
     allowDropdown=false
+    allowAutoFormat=false
     autoPlaceholder='aggressive'
     disabled=true
     required=required
@@ -70,6 +71,17 @@ export default Component.extend({
 
     this.allowDropdown = isPresent(this.allowDropdown)
       ? this.allowDropdown
+      : true;
+
+    /**
+      Whether or not to allow auto format phone number. If disabled, phone number will be applied as it is, without any transformations via internalization library.
+
+      @argument allowAutoFormat
+      @type {boolean}
+    */
+
+    this.allowAutoFormat = isPresent(this.allowAutoFormat)
+      ? this.allowAutoFormat
       : true;
 
     /**
@@ -149,10 +161,17 @@ export default Component.extend({
     );
   },
 
-  input() {
-    const internationalPhoneNumber = this._iti.getNumber();
-
+  input(event) {
     var meta = this._metaData(this._iti);
+    let internationalPhoneNumber;
+    
+    if (this.allowAutoFormat) {
+      internationalPhoneNumber = this._iti.getNumber();
+    } else {
+      const countryCode = meta.selectedCountryData;
+      internationalPhoneNumber = `+${countryCode} ${event.target.value}`;
+    }
+
     this.update(internationalPhoneNumber, meta);
 
     return true;
@@ -194,6 +213,7 @@ export default Component.extend({
   _setupLibrary() {
     const {
       allowDropdown,
+      allowAutoFormat,
       autoPlaceholder,
       initialCountry,
       onlyCountries,
@@ -206,6 +226,7 @@ export default Component.extend({
       autoHideDialCode: true,
       nationalMode: true,
       allowDropdown,
+      allowAutoFormat,
       autoPlaceholder,
       initialCountry,
       onlyCountries,
@@ -226,7 +247,7 @@ export default Component.extend({
   },
 
   _formatNumber() {
-    if (!this._iti) {
+    if (!this._iti || !this.allowAutoFormat) {
       return;
     }
 

--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -171,7 +171,7 @@ export default Component.extend({
   input(event) {
     var meta = this._metaData(this._iti);
     var internationalPhoneNumber;
-    
+
     if (this.allowAutoFormat) {
       internationalPhoneNumber = this._iti.getNumber();
     } else {

--- a/tests/dummy/app/pods/docs/components/phone-input/all-options/component.js
+++ b/tests/dummy/app/pods/docs/components/phone-input/all-options/component.js
@@ -19,7 +19,7 @@ export default Component.extend({
       this.set('separateDialNumber', separateDialNumber);
       this.setProperties(metaData);
     },
-    
+
     updateAllowAutoFormat(allowAutoFormatNumber, metaData) {
       this.set('allowAutoFormatNumber', allowAutoFormatNumber);
       this.setProperties(metaData);

--- a/tests/dummy/app/pods/docs/components/phone-input/all-options/component.js
+++ b/tests/dummy/app/pods/docs/components/phone-input/all-options/component.js
@@ -19,6 +19,16 @@ export default Component.extend({
       this.set('separateDialNumber', separateDialNumber);
       this.setProperties(metaData);
     },
+    
+    updateAllowAutoFormat(allowAutoFormatNumber, metaData) {
+      this.set('allowAutoFormatNumber', allowAutoFormatNumber);
+      this.setProperties(metaData);
+    },
+
+    updateDisallowAutoFormat(disallowAutoFormatNumber, metaData) {
+      this.set('disallowAutoFormatNumber', disallowAutoFormatNumber);
+      this.setProperties(metaData);
+    },
 
     submitForm() {
       alert('The form has been submitted');

--- a/tests/dummy/app/pods/docs/components/phone-input/all-options/template.hbs
+++ b/tests/dummy/app/pods/docs/components/phone-input/all-options/template.hbs
@@ -64,3 +64,27 @@
   {{demo.snippet "phone-input-required-option.hbs"}}
 {{/docs-demo}}
 
+<h2>`autocomplete` option</h2>
+{{#docs-demo as |demo|}}
+  {{#demo.example name="phone-input-autocomplete-option.hbs"}}
+    <p>{{phone-input autocomplete="tel" number=number}}</p>
+  {{/demo.example}}
+
+  {{demo.snippet "phone-input-autocomplete-option.hbs"}}
+{{/docs-demo}}
+
+<h2>`allowAutoFormat` option</h2>
+{{#docs-demo as |demo|}}
+    <p>The auto-format can be disabled (try to enter letters after numbers).</p>
+    <p><i>Example: 222qqqqqq</i></p>
+  {{#demo.example name="phone-input-allow-auto-format-option.hbs"}}
+    <p>{{phone-input allowAutoFormat=false number=disallowAutoFormatNumber initialCountry="us" update=(action "updateDisallowAutoFormat")}}</p>
+
+    <p>The auto-format enabled by default (letters will be transformed to numbers):</p>
+
+    <p>{{phone-input allowAutoFormat=true number=allowAutoFormatNumber initialCountry="us" update=(action "updateAllowAutoFormat")}}</p>
+
+  {{/demo.example}}
+
+  {{demo.snippet "phone-input-allow-auto-format-option.hbs"}}
+{{/docs-demo}}

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -39,6 +39,24 @@ module('Integration | Component | phone-input', function(hooks) {
     assert.dom('input').hasValue(newValue);
   });
 
+  test('letters transformation can be disabled', async function (assert) {
+    const newValue = '222test';
+    this.set('number', null);
+    this.set('update', () => { });
+
+    await render(hbs`{{phone-input allowAutoFormat=false number=number update=(action update)}}`);
+
+    assert.dom('input').hasValue('');
+
+    this.set('update', value => {
+      this.set('number', newValue);
+    });
+
+    await fillIn('input', newValue);
+
+    assert.dom('input').hasValue(newValue);
+  });
+
   test('renders the value with separate dial code option', async function(assert) {
     assert.expect(3);
 

--- a/tests/integration/components/phone-input-test.js
+++ b/tests/integration/components/phone-input-test.js
@@ -41,16 +41,18 @@ module('Integration | Component | phone-input', function(hooks) {
     assert.dom('input').hasValue(newValue);
   });
 
-  test('letters transformation can be disabled', async function (assert) {
+  test('letters transformation can be disabled', async function(assert) {
     const newValue = '222test';
     this.set('number', null);
-    this.set('update', () => { });
+    this.set('update', () => {});
 
-    await render(hbs`{{phone-input allowAutoFormat=false number=number update=(action update)}}`);
+    await render(
+      hbs`{{phone-input allowAutoFormat=false number=number update=(action update)}}`
+    );
 
     assert.dom('input').hasValue('');
 
-    this.set('update', value => {
+    this.set('update', () => {
       this.set('number', newValue);
     });
 


### PR DESCRIPTION
#### Description
**Bug description**: letters transformed to numbers on user input (trying to fit to valid phone number) - this behaviour was pretty confusing and we hadn't any options to turn-off this transformation.

**Solution:**
With `@allowAutoFormat={{false}}` option we can disable transformation, so user input remains unchanged.
Default value is `true`

#### Changes
[//]: # "Add if relevant, remove if not"
* new option added `@allowAutoFormat={{false}}`. If `false` - letters not transformed to numbers automatically.
* Added demo docs and test.

#### Screenshots
__Before:__

**input: +353 7890 test** _for both cases_

![image](https://user-images.githubusercontent.com/61147655/94448919-274c8780-01b4-11eb-8bd0-7c9e0daac6f2.png)


#### Reproduction instructions
[//]: # "Please add instructions to reproduce the changes."
→ 

### Checklist 
- [x] Obvisously, add your option

- [x] Do not forget to write inline documentation for your code in addon/components/phone-input

- [x] Add a test, probably in tests/integration/components/phone-input-test.js

- [x] Add a playground example in tests/dummy/app/pods/docs/components/phone-input/all-options/template