### PR TITLE
Ensure subsequent service:phone-input load calls are thenable

### DIFF
--- a/addon/services/phone-input.js
+++ b/addon/services/phone-input.js
@@ -1,13 +1,13 @@
 import Service from '@ember/service';
-import RSVP from 'rsvp';
+import { all, resolve } from 'rsvp';
 
 export default Service.extend({
   intlTelInput: null,
 
   load() {
-    if (this.intlTelInput) return;
+    if (this.intlTelInput) return resolve();
 
-    return RSVP.all([
+    return all([
       import('intl-tel-input/build/js/intlTelInput.js'),
       import('intl-tel-input/build/js/utils.js')
     ]).then(([intlTelInput]) => {

--- a/tests/unit/services/phone-input-test.js
+++ b/tests/unit/services/phone-input-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | phone-input', function(hooks) {
+  setupTest(hooks);
+
+  test('load is thenable on first and subsequent renders', function(assert) {
+    assert.expect(2);
+
+    let service = this.owner.lookup('service:phone-input');
+
+    service.load().then(() => {
+      assert.ok(true, 'the first load is thenable');
+    });
+
+    service.load().then(() => {
+      assert.ok(true, 'the second load is thenable');
+    });
+  });
+});


### PR DESCRIPTION
Thanks for an awesome addon :)

#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

I expected multiple calls to the service's load function to be thenable. They were actually returning `undefined` requiring additional logic on my end.

#### Changes
[//]: # "Add if relevant, remove if not"
* Return a `Promise` object that is resolved instantly rather than `undefined`.

#### Reproduction instructions

```js
beforeModel() {
  @service	
  phoneInput;

  return this.phoneInput.load().then(() => {
    return super.beforeModel(...arguments);
  });
}
```

The above code would have failed if phoneInput.load has already run with `Cannot read property 'then' of undefined`