### PR TITLE
WIP: Dont refresh the input for an invalid country code

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -253,9 +253,8 @@ export default Component.extend({
 
     if (selectedCountry.iso2) {
       this._iti.setCountry(selectedCountry.iso2);
+      this.input();
     }
-
-    this.input();
   },
 
   _metaData(iti) {


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

There is an issue where we can crash the app using the addon by having an invalid country code in the input.
If you initialize the addon with a value as `+33 6 12 34 56 78` and start deleting the text until `+3` remains, `_onCountryChange` will fire because the country indicator changed, but since the country indicator is invalid, the `input` method will be called without a country being set, then `_onCountryChange` will be reevaluated, and so on.

#### Reproduction instructions
[//]: # "Please add instructions to reproduce the changes."
→ Give the input an initial value of `+33 6 12 34 56 78` (or any phone number with it's country indicator)
→ Delete the number in the input until only the `+3`
→ By now your app should've crashed