### PR TITLE
drop support for node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: 10
+  NODE_VERSION: 12
   FORCE_COLOR: 1
 
 jobs:


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

This drops support for node 10 because the floating dependencies CI run is failing now that some of our sub dependencies have dropped support for it 😞 if only everyone followed semver 🙃 

Also now is the right time to do this anyway because Node 10 is EOL

#### Changes
[//]: # "Add if relevant, remove if not"
* change NODE_VERSION in the CI file from 10 to 12
