### PR TITLE
[refactor] use `this.element` directly

### DIFF
--- a/addon/components/phone-input.js
+++ b/addon/components/phone-input.js
@@ -211,8 +211,7 @@ export default Component.extend({
       separateDialCode
     } = this;
 
-    var input = document.getElementById(this.elementId);
-    var _iti = this.phoneInput.intlTelInput(input, {
+    var _iti = this.phoneInput.intlTelInput(this.element, {
       autoHideDialCode: true,
       nationalMode: true,
       allowDropdown,


### PR DESCRIPTION
#### Description
Current implementation uses `document.getElementById` with [`this.elementId`](https://api.emberjs.com/ember/3.27/classes/Component/properties/element?anchor=element) for targeting input element. This causes an issue with using angle-bracket invocation of `phone-input` in conjunction with passed `id`. Ember components allow us to avoid the `getElementById` call altogether and just use the in-scope [`this.element`](https://api.emberjs.com/ember/3.27/classes/Component/properties/element?anchor=element), which resolves the issue with angle-bracket implementation, and otherwise leaves functionality unchanged.

#### Changes
- updates element targeting to use `this.element`