### PR TITLE
CI: Run `deploy` CI job in the `github-pages` environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     needs: test
 
     strategy:
+      fail-fast: false
       matrix:
         ember-try-scenario:
           - 'ember-lts-3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
 
   deploy:
+    environment: github-pages
     name: Deploy
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."
The CI is currently failing on the main branch. Two kind of jobs are failing: 1/ deploy; 2/ tests for ember-beta & ember-canary. This PR would fix the 1/ deploy job.

#### An issue
The deploy job is missing a DEPLOY_KEY (see https://github.com/qonto/ember-phone-input/runs/3278460669). DEPLOY_KEY env var is needed to push to the gh-pages branch (and then deploy to Github Pages).

#### A solution
In the `github-pages` environment, the DEPLOY_KEY env var is set. So, merging this PR should fix `deploy`.

cc/ @mansona (as you recently worked on this)