### PR TITLE
Drop support for ember@3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - 'ember-lts-3.12'
           - 'ember-lts-3.16'
           - 'ember-lts-3.20'
           - 'ember-release'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ember install ember-phone-input
 
 ## Compatibility
 
-- Ember.js v3.12 or above
+- Ember.js v3.16 or above
 - Ember CLI v2.13 or above
 
 ## Contributing

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,14 +7,6 @@ module.exports = async function() {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.12',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.12.0'
-          }
-        }
-      },
-      {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."
The test scenario for ember@3.12 fails on the main branch. It doesn't mean that this addon doesn't work with ember@3.12. But it is a LTS that Ember.js itself no longer support. So let's drop the support for it.
