### PR TITLE
fix(documentation): Set application-template-wrapper to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,9 +88,6 @@
   "engines": {
     "node": "10.* || >= 12"
   },
-  "ember": {
-    "edition": "octane"
-  },
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "demoURL": "http://qonto.github.io/ember-phone-input/",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,5 +1,5 @@
 {
-  "application-template-wrapper": false,
+  "application-template-wrapper": true,
   "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true


### PR DESCRIPTION
#### Description
[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."

The PR fixes a css bug in the documentation website. As addon-docs applies a background color on the
template wrapper, we cannot set application-template-wrapper to false, it has to be true.

Then we remove the octane edition flag in the package.json. The app won't build if application-template-wrapper is enabled.

#### Changes
[//]: # "Add if relevant, remove if not"
* Set application-template-wrapper to true
* Remove octane edition flag

#### Screenshots
[//]: # "Please add screenshots if you made any UI changes."
<img width="697" alt="Capture d’écran 2021-09-10 à 10 48 18" src="https://user-images.githubusercontent.com/6677373/132827583-c6639a7c-b430-4d09-b84c-55c4c3761176.png">

#### Reproduction instructions
[//]: # "Please add instructions to reproduce the changes."
→ visit https://qonto.github.io/ember-phone-input/versions/master/