### PR TITLE
Remove remaining hasPrepend documentation

### DIFF
--- a/tests/dummy/app/pods/docs/installation/template.md
+++ b/tests/dummy/app/pods/docs/installation/template.md
@@ -9,26 +9,3 @@ ember install ember-phone-input
 In the `config.environment.js` you can add configurations for {{docs-link 'lazyloading' 'docs.lazy-loading'}} and asset paths.
 
 More information about lazy loading can be found {{docs-link 'here' 'docs.lazy-loading'}}
-
-#### Asset paths
-
-Lazying loading `ember-phone-input` two files will be downloaded when the `load()` is called.
-Those files are by default are concat the `rootURL` for your app. When deploying to production or staging server and you're using a CDN `ember-cli` gives you the [tools](https://ember-cli.com/user-guide/#fingerprinting-and-cdn-urls) to prepend the CDN URL to your assets. You will need to add `hasPrepend: true` to `config.environment.js` for the environments where you are using a CDN.
-
-```js
-module.exports = function(environment) {
-  const ENV = {
-    ...,
-    phoneInput: {
-      lazyLoad: true,    // default false
-      hasPrepend: false  // default false
-    }
-  }
-
-  if (deployTarget === 'production') {
-    ENV.phoneInput.hasPrepend = true;
-  }
-
-  return ENV
-}
-```

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -23,8 +23,7 @@ module.exports = function(environment) {
       // when it is created
     },
     phoneInput: {
-      lazyLoad: true,
-      hasPrepend: false
+      lazyLoad: true
     }
   };
 


### PR DESCRIPTION
#### Description
This configuration was removed in https://github.com/qonto/ember-phone-input/pull/151
when code was moved to ember-auto-import.

`hasPrepend` is not used anymore.