### PR TITLE
Remove IE 11 from the doc website targets

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers
 };


### PR DESCRIPTION
As IE 11 won't be supported in Ember v4