### PR TITLE
Disable automatic deployment of the website

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -1,28 +1,28 @@
-name: Deploy
+# name: Deploy
 
-env:
-  FORCE_COLOR: 1
+# env:
+#   FORCE_COLOR: 1
 
-on:
-  push:
-    branches:
-      - master
-    tags:
-      - '*'
+# on:
+#   push:
+#     branches:
+#       - master
+#     tags:
+#       - '*'
 
-jobs:
-  deploy:
-    environment: github-pages
-    env:
-      DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-    name: Deploy
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+# jobs:
+#   deploy:
+#     environment: github-pages
+#     env:
+#       DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+#     name: Deploy
+#     runs-on: ubuntu-latest
+#     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions/setup-node@v2
+#         with:
+#           node-version: ${{ env.NODE_VERSION }}
 
-      - run: yarn
-      - run: yarn ember deploy production
+#       - run: yarn
+#       - run: yarn ember deploy production


### PR DESCRIPTION
## Description

When deploying the website for the main branch, the asset path of the chunks dynamically imported (for example
`import('intl-tel-input/build/js/intlTelInput.js')`) is wrong.

For instance, webpack tries to load
https://qonto.github.io/ADDON_DOCS_ROOT_URL/assets/chunk.819.cee670bcd021ff0a6cf6.js
instead of
https://qonto.github.io/ember-phone-input/versions/master/assets/chunk.819.cee670bcd021ff0a6cf6.js

Why? There is a ember-cli-deploy plugin in ember-cli-addon-docs. Among other things, the plugin replaces the placeholder `ADDON_DOCS_ROOT_URL` in the generated assets files by `/ember-phone-input/versions/master/`. For some reason, the plugin doesn't replace the placeholder for dynamically imported chunks.

## Workaround

Fixing the issue in ember-cli-addon-docs would be probably complicated. So for now I use the following workaround to deploy it from my local machine. Run locally:
- `yarn ember deploy production`
- `git checkout gh-pages`
- search and replace `ADDON_DOCS_ROOT_URL` with `/ember-phone-input/versions/master/` (or `/ember-phone-input/versions/v7.0.0/` depending if I am deploying the website for the main branch or for a tag).