### PR TITLE
Add resilience for when scripts fail to load

### DIFF
--- a/tests/dummy/app/templates/docs/action-handling.md
+++ b/tests/dummy/app/templates/docs/action-handling.md
@@ -4,6 +4,13 @@
 
 Data changes that occur in the component are not propagated to the outside using two-way bindings, but rather they are communicated via the update action.
 
+Note that `ember-phone-input` can function without the `intl-tel-input` &
+`libphonenumber` scripts being loaded, in case if they load slowly or fail
+completely, but the user began interacting with the component. In both cases the
+`<input>` field's value as `number` and an empty `metaData` object is sent as
+`update` action arguments. If the scripts are loaded later, the component will
+proceed to initializing the scripts, keeping the value already entered.
+
 ## `update` action
 
 {{docs/components/phone-input/action-handling}}


### PR DESCRIPTION
#### Description
Covers the following cases:
1. The `intl-tel-input` & `libphonenumber` scripts are loaded after the user already interacted with the input (due to ex. slow network)
2. Scripts fail to load completely

In both cases the `input` action is fired with the input value and an empty `metaData` object to not to break clients relying on the latter always being an object.

When the scripts get loaded in the meantime, things will go on normally with an `intl-tel-input` initialized and will update the  meta, etc.

#### Changes
* Adds a `data-test-loading-iti` attribute to the component to be able the check the status
* Prevents setting up the library & all calls to `this._iti` when not loaded with component lifecycle in mind

#### Reproduction instructions
Throttle (and/or then block) network calls to the `intl-tel-input` libraries to see if the input can be interacted during while loading is in progress or failed.