### PR TITLE
Remove support for ember 3.16 and 3.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - 'ember-lts-3.16'
-          - 'ember-lts-3.20'
           - 'ember-release'
           - 'ember-beta'
           - 'ember-canary'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,22 +8,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0'
-          }
-        }
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5'
-          }
-        }
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
#### Description

In this PR support is removed for Ember v3.16 and Ember v3.20.

We are removing the support of these versions in order to enable Embroider: https://github.com/qonto/ember-phone-input/pull/584

#### Changes
* ember 3.16 and 3.20 are removed from `ember-try` configuration
