### PR TITLE
Add ability to pass a custom placeholder argument

### DIFF
--- a/ember-phone-input/src/components/phone-input.js
+++ b/ember-phone-input/src/components/phone-input.js
@@ -13,6 +13,7 @@ import '../styles/styles.css';
     {{phone-input
     allowDropdown=false
     autoPlaceholder='aggressive'
+    customPlaceholder='Enter phone number'
     disabled=true
     required=required
     autocomplete=autocomplete
@@ -102,6 +103,15 @@ export default Component.extend({
     this.autoPlaceholder = this.autoPlaceholder || 'polite';
 
     /**
+      Replace the auto placeholder with a custom placeholder.
+      If defined, must return a string. Defaults to null.
+
+      @argument customPlaceholder
+      @type {string}
+    */
+    this.customPlaceholder = this.customPlaceholder || null;
+
+    /**
       It will just be the first country in the list. Set the initial country by
       it's country code. Defaults to ''.
 
@@ -157,6 +167,13 @@ export default Component.extend({
       @param {boolean} metadata.isValidNumber The validity of the current `phoneNumber`.
     */
     this.update = this.update || function () {};
+
+    if (this.customPlaceholder) {
+      assert(
+        '`customPlaceholder` must be of type string',
+        typeof this.customPlaceholder === 'string'
+      );
+    }
 
     const validAutoPlaceholer = ['polite', 'aggressive', 'off'].includes(
       this.autoPlaceholder
@@ -233,6 +250,7 @@ export default Component.extend({
     const {
       allowDropdown,
       autoPlaceholder,
+      customPlaceholder,
       initialCountry,
       onlyCountries,
       preferredCountries,
@@ -244,6 +262,7 @@ export default Component.extend({
       nationalMode: true,
       allowDropdown,
       autoPlaceholder,
+      customPlaceholder: () => customPlaceholder,
       initialCountry,
       onlyCountries,
       preferredCountries,

--- a/test-app/tests/integration/components/phone-input-test.js
+++ b/test-app/tests/integration/components/phone-input-test.js
@@ -41,6 +41,20 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('input').hasValue(newValue);
   });
 
+  test('renders the custom placeholder', async function (assert) {
+    assert.expect(1);
+
+    this.set('number', null);
+    this.set('update', () => {});
+    this.set('customPlaceholder', 'A custom placeholder');
+
+    await render(
+      hbs`<PhoneInput @number={{this.number}} @update={{this.update}} @customPlaceholder={{this.customPlaceholder}} />`
+    );
+
+    assert.dom('input').hasAttribute('placeholder', this.customPlaceholder);
+  });
+
   test('renders the value with separate dial code option', async function (assert) {
     assert.expect(3);
 


### PR DESCRIPTION
#### Description

We offer the possibility to pass a custom placeholder (`customPlaceholder`) text to the component. If this is used, it will overwrite the existing `autoPlaceholder` attribute.

The new argument should be defined as a string. If it is defined, we assert the type in the component constructor.

It resolves #443.

#### Changes

* Introduce a new `customPlaceholder` argument on the component API

#### Screenshot

<img width="355" alt="custom-placeholder" src="https://user-images.githubusercontent.com/37348188/230630654-72fd9ece-44b8-4486-be10-0ad469d05163.png">

#### Reproduction instructions

The component should still work the same as before. If you pass a `@customPlaceholder` argument set to a string value, it will be used as a placeholder by the input.

### Checklist 
- [x] Add new argument
- [x] Write inline documentation in addon/components/phone-input
- [x] Add a test in tests/integration/components/phone-input-test.js
