### PR TITLE
Display autoPlaceholder when customPlaceholder is not provided

### DIFF
--- a/ember-phone-input/src/components/phone-input.js
+++ b/ember-phone-input/src/components/phone-input.js
@@ -257,17 +257,22 @@ export default Component.extend({
       separateDialCode
     } = this;
 
-    var _iti = this.phoneInput.intlTelInput(this.element, {
+    let options = {
       autoHideDialCode: true,
       nationalMode: true,
       allowDropdown,
       autoPlaceholder,
-      customPlaceholder: () => customPlaceholder,
       initialCountry,
       onlyCountries,
       preferredCountries,
       separateDialCode
-    });
+    };
+
+    if (customPlaceholder) {
+      options.customPlaceholder = () => customPlaceholder;
+    }
+
+    var _iti = this.phoneInput.intlTelInput(this.element, options);
 
     if (this.number) {
       _iti.setNumber(this.number);

--- a/test-app/tests/integration/components/phone-input-test.js
+++ b/test-app/tests/integration/components/phone-input-test.js
@@ -55,6 +55,17 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('input').hasAttribute('placeholder', this.customPlaceholder);
   });
 
+  test('renders auto placeholder if custom placeholder is not provided', async function (assert) {
+    this.set('number', null);
+    this.set('update', () => {});
+
+    await render(
+      hbs`<PhoneInput @number={{this.number}} @update={{this.update}} />`
+    );
+
+    assert.dom('input').hasAttribute('placeholder', '(201) 555-0123');
+  });
+
   test('renders the value with separate dial code option', async function (assert) {
     assert.expect(3);
 


### PR DESCRIPTION
`customPlaceholder` option has been added to the phone input: https://github.com/qonto/ember-phone-input/pull/589. When `customPlaceholder` value was not provided,  `null` placeholder appeared.

The correct behaviour is to display `autoPlaceholder` when `customPlaceholder` is missing. In this PR `customPlaceholder` option is set, only if its value is truthy.

