### PR TITLE
Replace autoHideDialCode by autoInsertDialCode

### DIFF
--- a/ember-phone-input/src/components/phone-input.js
+++ b/ember-phone-input/src/components/phone-input.js
@@ -258,7 +258,7 @@ export default Component.extend({
     } = this;
 
     let options = {
-      autoHideDialCode: true,
+      autoInsertDialCode: false,
       nationalMode: true,
       allowDropdown,
       autoPlaceholder,

--- a/test-app/tests/integration/components/phone-input-test.js
+++ b/test-app/tests/integration/components/phone-input-test.js
@@ -87,6 +87,12 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('input').hasValue(newValue);
   });
 
+  test('should not insert the dial code by default', async function (assert) {
+    await render(hbs`<PhoneInput />`);
+
+    assert.dom('input').hasValue('');
+  });
+
   test('can update the country', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
`intl-tel-input` has been upgraded to v18: https://github.com/qonto/ember-phone-input/pull/590

`intl-tel-input@18` has no more `autoHideDialCode` option, it has been replaced by `autoInsertDialCode`. In this PR `autoInsertDialCode` is introduced to the addon to follow the `intl-tel-input@18` changes.