### PR TITLE
Resolve PR link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### :house: Internal
 
-- [#625] Migrate from yarn to pnpm ([@vscav](https://github.com/vscav))
+- [#625](https://github.com/qonto/ember-phone-input/pull/625) Migrate from yarn to pnpm ([@vscav](https://github.com/vscav))
 
 #### Committers: 1
 


### PR DESCRIPTION
In this MR, we add a missing link in the last release (v9.0.1) section of the changelog. We also did the same in the [release description of the repository](https://github.com/qonto/ember-phone-input/releases/tag/v9.0.1).