### PR TITLE
Remove double node installation on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,14 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: "https://registry.npmjs.org"
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16
+          node-registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: pnpm install
       - name: Build addon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test
@@ -57,14 +54,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test
@@ -81,14 +75,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
           no-lockfile: true
       - name: Install dependencies
         run: pnpm install --no-lockfile


### PR DESCRIPTION
`NullVoxPopuli/action-setup-pnpm` already handles the node setup. So we were running `actions/setup-node` twice.