### PR TITLE
Remove double pnpm installation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          args: "--frozen-lockfile"
       - name: Run Lint
         run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
           pnpm-version: 8.5.1
           node-version: 16
           node-registry-url: "https://registry.npmjs.org"
-      - name: Install dependencies
-        run: pnpm install
       - name: Build addon
         run: pnpm build
       - name: auto-dist-tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          args: "--frozen-lockfile"
       - name: Test
         run: pnpm test:ember
         working-directory: test-app
@@ -59,8 +58,7 @@ jobs:
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          args: "--frozen-lockfile"
       - name: Test
         run: pnpm ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
         working-directory: test-app
@@ -81,8 +79,6 @@ jobs:
           pnpm-version: 8.5.1
           node-version: 16.x
           args: "--no-lockfile"
-      - name: Install dependencies
-        run: pnpm install --no-lockfile
       - name: Test
         run: pnpm test:ember
         working-directory: test-app


### PR DESCRIPTION
This MR removes the double `pnpm install`: `NullVoxPopuli/action-setup-pnpm` already calls `pnpm install` and [expose an `args` input](https://github.com/NullVoxPopuli/action-setup-pnpm#args).