### PR TITLE
Fix cannot clear a number via falsy number parameter

### DIFF
--- a/ember-phone-input/src/components/phone-input.js
+++ b/ember-phone-input/src/components/phone-input.js
@@ -297,6 +297,8 @@ export default Component.extend({
 
     if (this.number) {
       this._iti.setNumber(this.number);
+    } else {
+      this._iti.setNumber('');
     }
   },
 

--- a/test-app/tests/integration/components/phone-input-test.js
+++ b/test-app/tests/integration/components/phone-input-test.js
@@ -19,9 +19,9 @@ module('Integration | Component | phone-input', function (hooks) {
   });
 
   test('renders the value', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
-    const newValue = '2';
+    let newValue = '2';
     this.set('number', null);
     this.set('update', () => {});
 
@@ -39,6 +39,11 @@ module('Integration | Component | phone-input', function (hooks) {
     await fillIn('input', newValue);
 
     assert.dom('input').hasValue(newValue);
+
+    this.set('number', null);
+    newValue = null;
+
+    assert.dom('input').hasValue('');
   });
 
   test('renders the custom placeholder', async function (assert) {


### PR DESCRIPTION
This is another fix for issue #146 

Unlike the previous fix by @pierreavn #314 , this doesn't produce an error if this.number is set to null or undefined.

This also includes a test.