### PR TITLE
chore(ci): update pnpm github action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           pnpm-version: 8.5.1
           node-version: 16.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           pnpm-version: 8.5.1
           node-version: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
@@ -76,11 +76,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install pnpm
-        uses: NullVoxPopuli/action-setup-pnpm@v2
+        uses: wyvox/action-setup-pnpm@v3
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-          no-lockfile: true
+          args: "--no-lockfile"
       - name: Install dependencies
         run: pnpm install --no-lockfile
       - name: Test


### PR DESCRIPTION
We're updating the pnpm installation github action from `NullVoxPopuli/action-setup-pnpm@v2` to `wyvox/action-setup-pnpm@v3` due to deprecation.