### PR TITLE
Bump embroider versions in ember-try config

### DIFF
--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -65,8 +65,24 @@ module.exports = async function () {
           }
         }
       },
-      embroiderSafe(),
-      embroiderOptimized()
+      embroiderSafe({
+        npm: {
+          devDependencies: {
+            '@embroider/compat': '^3.2.1',
+            '@embroider/core': '^3.2.1',
+            '@embroider/webpack': '^3.1.5'
+          }
+        }
+      }),
+      embroiderOptimized({
+        npm: {
+          devDependencies: {
+            '@embroider/compat': '^3.2.1',
+            '@embroider/core': '^3.2.1',
+            '@embroider/webpack': '^3.1.5'
+          }
+        }
+      })
     ]
   };
 };


### PR DESCRIPTION
Ember-try's default configuration with pnpm installs lower versions of embroider devDependencies when running ember-try scenarios. In this MR we're bumping embroider dependencies in ember-try config to make sure newer versions are installed in order to fix embroider ember-try CI jobs failing.