### PR TITLE
Fix typos after migrating to glimmer component

### DIFF
--- a/ember-phone-input/src/components/phone-input.hbs
+++ b/ember-phone-input/src/components/phone-input.hbs
@@ -7,6 +7,6 @@
   {{did-insert this.onDidInsert}}
   {{did-update this.onDidUpdate @country @number}}
   {{will-destroy this.onDestroy}}
-  data-test-loading-iti={{this.loadingIti}}
+  data-test-loading-iti={{this.isLoadingIti}}
   type={{this.type}}
 />

--- a/ember-phone-input/src/components/phone-input.js
+++ b/ember-phone-input/src/components/phone-input.js
@@ -239,9 +239,7 @@ export default class PhoneInputComponent extends Component {
         this._onCountryChange.bind(this)
       );
     } catch (error) {
-      if (this.onError) {
-        this.onError(error);
-      }
+      this.args.onError?.(error);
     } finally {
       if (!this.isDestroying && !this.isDestroyed) {
         this.isLoadingIti = false;


### PR DESCRIPTION
This PR aims to fix typos made during migration from Ember classic component to Glimmer component