### PR TITLE
Replace broken Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ember-phone-input
 
-[![Build Status](https://img.shields.io/travis/qonto/ember-phone-input.svg?style=flat)](https://travis-ci.com/qonto/ember-phone-input)
+![CI](https://github.com/qonto/ember-phone-input/workflows/CI/badge.svg)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-phone-input.svg)](https://emberobserver.com/addons/ember-phone-input)
 
 Easily create phone input. With internationalization and validation in mind.


### PR DESCRIPTION
With this PR, the broken Travis CI badge is replaced with a passing CI badge.

The old badge is broken (we're not using Travis anymore) and the new one is consistent with other Qonto open source repositories.

| Before | After |
|--------|--------|
| <img src="https://github.com/qonto/ember-phone-input/assets/73175085/aae9d7ad-7222-4279-9233-8d06f8855548" width="300" /> |  <img src="https://github.com/qonto/ember-phone-input/assets/73175085/ec3c5ade-8890-446c-80da-9c97a385d6aa" width="300" />|