### PR TITLE
feat(ts-lint): allow use of private and protected syntax for classes in .ts files

### DIFF
--- a/ember-phone-input/.eslintrc.cjs
+++ b/ember-phone-input/.eslintrc.cjs
@@ -79,19 +79,6 @@ module.exports = {
             accessibility: 'no-public'
           }
         ],
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector:
-              ':matches(PropertyDefinition, MethodDefinition)[accessibility="private"]',
-            message: 'Use #private instead'
-          },
-          {
-            selector:
-              ':matches(PropertyDefinition, MethodDefinition)[accessibility="protected"]',
-            message: 'Use #private instead'
-          }
-        ],
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/member-delimiter-style': 'error',
         '@typescript-eslint/member-ordering': 'error',

--- a/test-app/.eslintrc.js
+++ b/test-app/.eslintrc.js
@@ -85,19 +85,6 @@ module.exports = {
             accessibility: 'no-public'
           }
         ],
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector:
-              ':matches(PropertyDefinition, MethodDefinition)[accessibility="private"]',
-            message: 'Use #private instead'
-          },
-          {
-            selector:
-              ':matches(PropertyDefinition, MethodDefinition)[accessibility="protected"]',
-            message: 'Use #private instead'
-          }
-        ],
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/member-delimiter-style': 'error',
         '@typescript-eslint/member-ordering': 'error',


### PR DESCRIPTION
In this PR, we update the rules in our TS eslint config to allow the use of the `private` and `protected` keywords in TypeScript classes definition.