### PR TITLE
feat: use `Sinon.JS` in integration tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@types/qunit':
         specifier: 2.19.8
         version: 2.19.8
+      '@types/sinon':
+        specifier: ^17.0.2
+        version: 17.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: 6.11.0
         version: 6.11.0(@typescript-eslint/parser@6.11.0)(eslint@8.53.0)(typescript@5.2.2)
@@ -253,6 +256,9 @@ importers:
       ember-resolver:
         specifier: 11.0.1
         version: 11.0.1(ember-source@5.4.0)
+      ember-sinon-qunit:
+        specifier: ^7.4.0
+        version: 7.4.0(ember-source@5.4.0)(qunit@2.20.0)(sinon@17.0.1)
       ember-source:
         specifier: 5.4.0
         version: 5.4.0(@babel/core@7.23.3)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(rsvp@4.8.5)(webpack@5.89.0)
@@ -322,6 +328,9 @@ importers:
       release-it-lerna-changelog:
         specifier: 5.0.0
         version: 5.0.0(release-it@16.2.1)
+      sinon:
+        specifier: ^17.0.1
+        version: 17.0.1
       tracked-built-ins:
         specifier: 3.3.0
         version: 3.3.0
@@ -3205,6 +3214,42 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
+  /@sinonjs/commons@2.0.0:
+    resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/commons@3.0.0:
+    resolution: {integrity: sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/fake-timers@10.3.0:
+    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+    dependencies:
+      '@sinonjs/commons': 3.0.0
+    dev: true
+
+  /@sinonjs/fake-timers@11.2.2:
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.0
+    dev: true
+
+  /@sinonjs/samsam@8.0.0:
+    resolution: {integrity: sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+      lodash.get: 4.4.2
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/text-encoding@0.7.2:
+    resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
+    dev: true
+
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: true
@@ -3453,6 +3498,22 @@ packages:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
       '@types/node': 20.8.10
+    dev: true
+
+  /@types/sinon@10.0.20:
+    resolution: {integrity: sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.5
+    dev: true
+
+  /@types/sinon@17.0.2:
+    resolution: {integrity: sha512-Zt6heIGsdqERkxctIpvN5Pv3edgBrhoeb3yHyxffd4InN0AX2SVNKSrhdDZKGQICVOxWP/q4DyhpfPNMSrpIiA==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.5
+    dev: true
+
+  /@types/sinonjs__fake-timers@8.1.5:
+    resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
     dev: true
 
   /@types/sizzle@2.3.5:
@@ -7938,6 +7999,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /ember-sinon-qunit@7.4.0(ember-source@5.4.0)(qunit@2.20.0)(sinon@17.0.1):
+    resolution: {integrity: sha512-BcH2scgJ4Vpq5Fnjeq5Z2ESnHLsmcfFRaq/gOujy3my+8w7WTtrHyaUgWzmd5mLw+tfCYssAUEalQhk1ZNpV+g==}
+    peerDependencies:
+      ember-source: '>=3.28.0'
+      qunit: ^2.0.0
+      sinon: ^15.0.3 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@embroider/addon-shim': 1.8.6
+      '@types/sinon': 10.0.20
+      ember-source: 5.4.0(@babel/core@7.23.3)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(rsvp@4.8.5)(webpack@5.89.0)
+      qunit: 2.20.0
+      sinon: 17.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ember-source-channel-url@3.0.0:
     resolution: {integrity: sha512-vF/8BraOc66ZxIDo3VuNP7iiDrnXEINclJgSJmqwAAEpg84Zb1DHPI22XTXSDA+E8fW5btPUxu65c3ZXi8AQFA==}
     engines: {node: 10.* || 12.* || >= 14}
@@ -11134,6 +11211,10 @@ packages:
       verror: 1.10.0
     dev: true
 
+  /just-extend@4.2.1:
+    resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
+    dev: true
+
   /keyv@3.1.0:
     resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
     dependencies:
@@ -11466,6 +11547,10 @@ packages:
 
   /lodash.foreach@4.5.0:
     resolution: {integrity: sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==}
+    dev: true
+
+  /lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
 
   /lodash.isarguments@3.1.0:
@@ -12354,6 +12439,16 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
 
+  /nise@5.1.5:
+    resolution: {integrity: sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+      '@sinonjs/fake-timers': 10.3.0
+      '@sinonjs/text-encoding': 0.7.2
+      just-extend: 4.2.1
+      path-to-regexp: 1.8.0
+    dev: true
+
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -13061,6 +13156,12 @@ packages:
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: true
+
+  /path-to-regexp@1.8.0:
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+    dependencies:
+      isarray: 0.0.1
     dev: true
 
   /path-type@3.0.0:
@@ -14467,6 +14568,17 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
+    dev: true
+
+  /sinon@17.0.1:
+    resolution: {integrity: sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==}
+    dependencies:
+      '@sinonjs/commons': 3.0.0
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.0
+      diff: 5.1.0
+      nise: 5.1.5
+      supports-color: 7.2.0
     dev: true
 
   /slash@1.0.0:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -38,6 +38,7 @@
     "@qonto/eslint-config-typescript": "1.0.0-rc.0",
     "@tsconfig/ember": "3.0.2",
     "@types/qunit": "2.19.8",
+    "@types/sinon": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "6.11.0",
     "@typescript-eslint/parser": "6.11.0",
     "broccoli-asset-rev": "3.0.0",
@@ -64,6 +65,7 @@
     "ember-page-title": "8.1.0",
     "ember-qunit": "8.0.2",
     "ember-resolver": "11.0.1",
+    "ember-sinon-qunit": "^7.4.0",
     "ember-source": "5.4.0",
     "ember-source-channel-url": "3.0.0",
     "ember-template-lint": "5.12.0",
@@ -87,6 +89,7 @@
     "qunit-dom": "3.0.0",
     "release-it": "16.2.1",
     "release-it-lerna-changelog": "5.0.0",
+    "sinon": "^17.0.1",
     "tracked-built-ins": "3.3.0",
     "typescript": "5.2.2",
     "webpack": "5.89.0"

--- a/test-app/tests/integration/components/phone-input-test.ts
+++ b/test-app/tests/integration/components/phone-input-test.ts
@@ -8,10 +8,12 @@ import type {
 } from 'ember-phone-input/components/phone-input';
 import { setupRenderingTest } from 'ember-qunit';
 import QUnit, { module, test } from 'qunit';
+import sinon from 'sinon';
 
 interface TestContext extends PhoneInputArgs, TestContextBase {
   metaData: MetaData | null;
   separateDialNumber: PhoneInputArgs['number'];
+  spiedUpdate: sinon.SinonSpy;
   updateAllowDropdownNumber: () => void;
 }
 
@@ -38,26 +40,21 @@ module('Integration | Component | phone-input', function (hooks) {
   });
 
   test('renders the value', async function (this: TestContext, assert) {
-    assert.expect(3);
-
     const newValue = '2';
 
     this.number = null;
-    this.update = NOOP;
+    this.spiedUpdate = sinon.spy();
 
     await render<TestContext>(
-      hbs`<PhoneInput @number={{this.number}} @update={{action this.update}} />`
+      hbs`<PhoneInput @number={{this.number}} @update={{this.spiedUpdate}} />`
     );
 
     assert.dom('input').hasValue('');
 
-    this.set('update', (number: PhoneInputArgs['number']): void => {
-      assert.strictEqual(number, newValue);
-      this.set('number', newValue);
-    });
-
     await fillIn('input', newValue);
 
+    const [inputValue] = this.spiedUpdate.lastCall.args;
+    assert.strictEqual(inputValue, newValue);
     assert.dom('input').hasValue(newValue);
   });
 
@@ -131,57 +128,57 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('.iti__flag').hasClass('iti__nz');
   });
 
-  test('invalidates phone number when country is changed', async function (this: TestContext, assert) {
-    assert.expect(7);
-
+  test('invalidates the phone number when country is changed', async function (this: TestContext, assert) {
     const country = 'fr';
     const validFrenchNumber = '0622334455';
 
     this.country = country;
     this.number = null;
-    this.update = NOOP;
+    this.spiedUpdate = sinon.spy();
 
     await render<TestContext>(
-      hbs`<PhoneInput @country={{this.country}} @number={{this.number}} @update={{action this.update}} />`
-    );
-
-    this.set(
-      'update',
-      (
-        _number: PhoneInputArgs['number'],
-        {
-          isValidNumber,
-          numberFormat
-        }: Pick<MetaData, 'isValidNumber' | 'numberFormat'>
-      ): void => {
-        assert.ok(isValidNumber);
-        assert.strictEqual(numberFormat?.E164, '+33622334455');
-        assert.strictEqual(numberFormat?.INTERNATIONAL, '+33 6 22 33 44 55');
-        assert.strictEqual(numberFormat?.NATIONAL, '06 22 33 44 55');
-        assert.strictEqual(numberFormat?.RFC3966, 'tel:+33-6-22-33-44-55');
-      }
+      hbs`<PhoneInput @country={{this.country}} @number={{this.number}} @update={{this.spiedUpdate}} />`
     );
 
     await fillIn('input', validFrenchNumber);
 
-    this.set(
-      'update',
-      (
-        _number: PhoneInputArgs['number'],
-        {
-          isValidNumber,
-          numberFormat
-        }: Pick<MetaData, 'isValidNumber' | 'numberFormat'>
-      ): void => {
-        assert.notOk(isValidNumber);
-        assert.strictEqual(numberFormat, null);
+    const [, onPhoneInputCallMetaData] = this.spiedUpdate.lastCall.args;
+    assert.deepEqual(onPhoneInputCallMetaData, {
+      extension: null,
+      selectedCountryData: {
+        name: 'France',
+        iso2: 'fr',
+        dialCode: '33',
+        priority: 0,
+        areaCodes: null
+      },
+      isValidNumber: true,
+      numberFormat: {
+        E164: '+33622334455',
+        INTERNATIONAL: '+33 6 22 33 44 55',
+        NATIONAL: '06 22 33 44 55',
+        RFC3966: 'tel:+33-6-22-33-44-55'
       }
-    );
+    });
 
     this.set('country', 'pt');
+
+    const [, onCountryUpdatedCallMetaData] = this.spiedUpdate.lastCall.args;
+    assert.deepEqual(onCountryUpdatedCallMetaData, {
+      extension: null,
+      selectedCountryData: {
+        name: 'Portugal',
+        iso2: 'pt',
+        dialCode: '351',
+        priority: 0,
+        areaCodes: null
+      },
+      isValidNumber: false,
+      numberFormat: null
+    });
   });
 
-  test('can be disabled', async function (this: TestContext, assert) {
+  test('is disabled', async function (this: TestContext, assert) {
     this.number = null;
     this.update = NOOP;
 
@@ -276,16 +273,16 @@ module('Integration | Component | phone-input', function (hooks) {
 
       this.metaData = null;
       this.number = null;
-      this.set(
-        'update',
-        (number: PhoneInputArgs['number'], metaData: MetaData): void => {
-          this.set('metaData', metaData);
-          this.set('number', number);
-        }
-      );
+      this.update = (
+        number: PhoneInputArgs['number'],
+        metaData: MetaData
+      ): void => {
+        this.set('metaData', metaData);
+        this.set('number', number);
+      };
 
       await render<TestContext>(
-        hbs`<PhoneInput @number={{this.number}} @update={{action this.update}} />`
+        hbs`<PhoneInput @number={{this.number}} @update={{this.update}} />`
       );
 
       assert.dom('input').doesNotHaveAttribute('data-intl-tel-input-id');

--- a/test-app/tests/integration/components/phone-input-test.ts
+++ b/test-app/tests/integration/components/phone-input-test.ts
@@ -104,7 +104,7 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('input').hasValue(newValue);
   });
 
-  test('should not insert the dial code by default', async function (this: TestContext, assert) {
+  test('does not insert the dial code by default', async function (this: TestContext, assert) {
     this.number = null;
     this.update = NOOP;
 
@@ -115,7 +115,7 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('input').hasValue('');
   });
 
-  test('can update the country', async function (this: TestContext, assert) {
+  test('updates the country', async function (this: TestContext, assert) {
     this.country = 'us';
     this.number = null;
     this.update = NOOP;
@@ -131,7 +131,7 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('.iti__flag').hasClass('iti__nz');
   });
 
-  test('phoneNumber is correctly invalid when country is changed', async function (this: TestContext, assert) {
+  test('invalidates phone number when country is changed', async function (this: TestContext, assert) {
     assert.expect(7);
 
     const country = 'fr';
@@ -188,10 +188,10 @@ module('Integration | Component | phone-input', function (hooks) {
     await render<TestContext>(
       hbs`<PhoneInput @disabled={{true}} @number={{this.number}} @update={{this.update}} />`
     );
-    assert.ok(find('input').disabled);
+    assert.ok(find('input')?.disabled);
   });
 
-  test('can be required', async function (this: TestContext, assert) {
+  test('is required', async function (this: TestContext, assert) {
     this.number = null;
     this.update = NOOP;
 
@@ -199,10 +199,10 @@ module('Integration | Component | phone-input', function (hooks) {
       hbs`<PhoneInput @required={{true}} @number={{this.number}} @update={{this.update}} />`
     );
 
-    assert.ok(find('input').required);
+    assert.ok(find('input')?.required);
   });
 
-  test('can prevent the dropdown', async function (this: TestContext, assert) {
+  test('prevents the dropdown', async function (this: TestContext, assert) {
     this.number = null;
     this.updateAllowDropdownNumber = NOOP;
 
@@ -213,7 +213,7 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('ul.country-list').doesNotExist();
   });
 
-  test('can set autocomplete', async function (this: TestContext, assert) {
+  test('sets autocomplete', async function (this: TestContext, assert) {
     this.number = null;
     this.update = NOOP;
 
@@ -221,10 +221,10 @@ module('Integration | Component | phone-input', function (hooks) {
       hbs`<PhoneInput @autocomplete={{"tel"}} @number={{this.number}} @update={{this.update}} />`
     );
 
-    assert.strictEqual(find('input').autocomplete, 'tel');
+    assert.strictEqual(find('input')?.autocomplete, 'tel');
   });
 
-  test('can update the country when the user types in the digits from Brazil code', async function (this: TestContext, assert) {
+  test('updates the country when the user types in the digits from Brazil code', async function (this: TestContext, assert) {
     this.number = null;
     this.update = NOOP;
 
@@ -237,7 +237,7 @@ module('Integration | Component | phone-input', function (hooks) {
     assert.dom('.iti__flag').hasClass('iti__br');
   });
 
-  test('can update the country when the user types in the digits from Malaysia code', async function (this: TestContext, assert) {
+  test('updates the country when the user types in the digits from Malaysia code', async function (this: TestContext, assert) {
     this.number = null;
     this.update = NOOP;
 

--- a/test-app/tests/test-helper.ts
+++ b/test-app/tests/test-helper.ts
@@ -1,12 +1,15 @@
-import Application from 'test-app/app';
-import config from 'test-app/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import Application from 'test-app/app';
+import config from 'test-app/config/environment';
+import setupSinon from 'ember-sinon-qunit';
 
 setup(QUnit.assert);
 
 setApplication(Application.create(config.APP));
+
+setupSinon();
 
 start();


### PR DESCRIPTION
In this PR, we install and set up `sinon` to use in our integration tests, and create `spies` for the `update` function passed to the `PhoneInput` component. It also allows us to fix a failing `ember-canary` job (temporarily, as unstable by definition).