### PR TITLE
Extract release-it config to own file

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -1,0 +1,20 @@
+module.exports = {
+  plugins: {
+    "@release-it-plugins/lerna-changelog": {
+      infile: "CHANGELOG.md",
+      launchEditor: true,
+    },
+    "@release-it-plugins/workspaces": true,
+  },
+  git: {
+    tagName: "v${version}",
+    commitMessage: "chore: release v${version}",
+  },
+  github: {
+    release: true,
+  },
+  npm: false,
+  hooks: {
+    "after:bump": "pnpm i --frozen-lockfile=false",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -38,22 +38,5 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
-  },
-  "release-it": {
-    "plugins": {
-      "@release-it-plugins/lerna-changelog": {
-        "infile": "CHANGELOG.md",
-        "launchEditor": false
-      },
-      "@release-it-plugins/workspaces": true
-    },
-    "git": {
-      "tagName": "v${version}"
-    },
-    "github": {
-      "release": true,
-      "tokenRef": "GITHUB_AUTH"
-    },
-    "npm": false
   }
 }


### PR DESCRIPTION
To avoid overcomplicating the `package.json` file, we extract the release-it configuration block to its own file.

In addition to that, we:
* set `launchEditor` to `true`
* set a `commitMessage` template for releases
* remove `tokenRef` from the `github` block
* add a hook to prevent lockfile update issues on release
